### PR TITLE
Update ds_config_sample.py

### DIFF
--- a/app/ds_config_sample.py
+++ b/app/ds_config_sample.py
@@ -25,7 +25,7 @@ DS_CONFIG = {
     "gateway_display_name": "Stripe",
     "github_example_url": "https://github.com/docusign/code-examples-python/tree/master/app/",
     "documentation": "",  # Use an empty string to indicate no documentation path.
-    "quickstart": "{QUICKSTART_VALUE}"
+    "quickstart": False # When set to True, only the first code example is available in the examples menu.
 }
 
 DS_JWT = {


### PR DESCRIPTION
Set the default value of "quickstart" to False in ds_config_sample.py. This is a boolean and when set to anything other than False (no quotes) it evaluates to True and only the Quickstart menu is available. (For example, "False", "false", or false will all either return True or throw an error.)