### PR TITLE
Wrong form id for the phone number in template

### DIFF
--- a/app/templates/eg020_sms_authentication.html
+++ b/app/templates/eg020_sms_authentication.html
@@ -24,7 +24,7 @@
     
     <div class="form-group">
         <label for="phoneNumber">SMS Number</label>
-        <input type="tel" class="form-control" id="phoneNumber" name="phoneNumber"
+        <input type="tel" class="form-control" id="phone_number" name="phone_number"
                aria-describedby="accessHelp" placeholder="415-555-1212" required
                value="415-555-1212">
         <small id="accessHelp" class="form-text text-muted">Send a text message to this phone number to verify recipient.</small>


### PR DESCRIPTION
So, in the controller ./app/eSignature/examples/eg020_sms_authentication/controller.py we have phone_number = request.form.get("phone_number"), but in template this phone field was "phoneNumber", that caused issue. Envelope was sent, but receiver cannot open that, cause it was no number specified. 
Small change, after i tested the DocuSign example for my project need.