### PR TITLE
Fix typo in code comment

### DIFF
--- a/app/docusign/ds_client.py
+++ b/app/docusign/ds_client.py
@@ -103,7 +103,7 @@ class DSClient:
         except ApiException as err:
             body = err.body.decode('utf8')
 
-            # Grand explicit consent for the application
+            # Grant explicit consent for the application
             if "consent_required" in body:
                 consent_scopes = " ".join(use_scopes)
                 redirect_uri = DS_CONFIG["app_url"] + url_for("ds.ds_callback")


### PR DESCRIPTION
Found a minor typo of "Grand" that should be "Grant" in a code comment for the `_jwt_auth` class method.